### PR TITLE
add erlang:unregister/1

### DIFF
--- a/priv/funcs.txt
+++ b/priv/funcs.txt
@@ -97,6 +97,7 @@ erlang:spawn/3
 erlang:spawn_opt/2
 erlang:spawn_opt/4
 erlang:system_info/1
+erlang:unregister/1
 erlang:whereis/1
 erlang:++/2
 erlang:system_time/1


### PR DESCRIPTION
add erlang:unregister/1 to priv/funcs.txt to allow the use of `Process.unregister/1` and `:erlang.unregister/1` in mix compiled elixir applications.

Signed-off-by: Winford <dwinford@pm.me>