### PR TITLE
Exit code 1 on mix task errors

### DIFF
--- a/lib/mix/tasks/check.ex
+++ b/lib/mix/tasks/check.ex
@@ -12,6 +12,8 @@ defmodule Mix.Tasks.Atomvm.Check do
     with :ok <- instructions_check,
          :ok <- ext_calls_check do
       {:ok, []}
+    else
+      _any -> exit({:shutdown, 1})
     end
   end
 

--- a/lib/mix/tasks/esp32_flash.ex
+++ b/lib/mix/tasks/esp32_flash.ex
@@ -23,15 +23,15 @@ defmodule Mix.Tasks.Atomvm.Esp32.Flash do
     else
       {:atomvm, :error} ->
         IO.puts("error: missing AtomVM project config.")
-        :error
+        exit({:shutdown, 1})
 
       {:args, :error} ->
         IO.puts("Syntax: ")
-        :error
+        exit({:shutdown, 1})
 
       {:pack, _} ->
         IO.puts("error: failed PackBEAM, target will not be flashed.")
-        :error
+        exit({:shutdown, 1})
     end
   end
 


### PR DESCRIPTION
this helps for tooling calling the mix tasks eg. I'm using the mix tasks from within vscode/platformio for improved DX.

Replaces https://github.com/atomvm/ExAtomVM/pull/5 - due to git snafu..