### PR TITLE
Add missing GPIO commands

### DIFF
--- a/priv/funcs.txt
+++ b/priv/funcs.txt
@@ -526,9 +526,16 @@ Elixir.Enum:reduce/3
 Elixir.Enum:reject/2
 Elixir.GPIO:__info__/1
 Elixir.GPIO:attach_interrupt/2
+Elixir.GPIO:close/1
+Elixir.GPIO:deep_sleep_hold_dis/0
+Elixir.GPIO:deep_sleep_hold_en/0
+Elixir.GPIO:deinit/1
 Elixir.GPIO:detach_interrupt/1
 Elixir.GPIO:digital_read/1
 Elixir.GPIO:digital_write/2
+Elixir.GPIO:hold_dis/0
+Elixir.GPIO:hold_en/0
+Elixir.GPIO:init/1
 Elixir.GPIO:module_info/0
 Elixir.GPIO:module_info/1
 Elixir.GPIO:open/0
@@ -538,6 +545,9 @@ Elixir.GPIO:set_direction/3
 Elixir.GPIO:set_int/3
 Elixir.GPIO:set_level/3
 Elixir.GPIO:set_pin_mode/2
+Elixir.GPIO:set_pin_pull/2
+Elixir.GPIO:start/0
+Elixir.GPIO:stop/0
 Elixir.Kernel:__info__/1
 Elixir.Kernel:inspect/1
 Elixir.Kernel:inspect/2


### PR DESCRIPTION
Added support for several GPIO driver commands missing from `func.txt`.