### PR TITLE
Add STM32 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Example:
 
 The `atomvm.esp32.flash` task is used to flash your application to a micro-controller and executed by the AtomVM virtual machine.
 
-> Note.  Before running this task, you must flash the AtomVM virtual machine to the device.  See the [AtomVM documentation](https://doc.atomvm.net) for information about how to flash the AtomVM image to a device.
+> Note.  Before running this task, you must flash the AtomVM virtual machine to the device.  See the [Getting Started](https://www.atomvm.net/doc/master/getting-started-guide.html) section if the [AtomVM documentation](https://www.atomvm.net/doc/master/) for information about how to flash the AtomVM image to a device.
 
 The `atomvm` properties list in the Mix project file (`mix.exs`) may contain the following entries related to this task:
 
@@ -363,3 +363,53 @@ Example:
 
     Leaving...
     Hard resetting via RTS pin...
+
+### The `atomvm.stm32.flash` task
+
+The `atomvm.stm32.flash` task is used to flash your application to a micro-controller and executed by the AtomVM virtual machine.
+
+> Note.  Before running this task, you must flash the AtomVM virtual machine to the device.  See the [Getting Started](https://www.atomvm.net/doc/master/getting-started-guide.html) section if the [AtomVM documentation](https://www.atomvm.net/doc/master/) for information about how to flash the AtomVM image to a device.
+
+The `atomvm` properties list in the Mix project file (`mix.exs`) may contain the following entries related to this task:
+
+| Key | Type | Default | Value |
+|-----|------|----------|-------|
+| `stflash_path` | string | undefined | The full path to the `st-flash` utility, if not in users PATH |
+| `flash_offset` | Address in hexademical format | 0x8080000 | The beginning flash address to write to  |
+
+Properties in the `mix.exs` file may be over-ridden on the command line using long-style flags (prefixed by `--`) by the same name as the properties key.  For example, you can use the `--stflash_path` option to specify or override the `stflash_path` property in the above table.
+
+Example:
+
+    shell$ mix atomvm.stm32.flash
+    warning: GPIO.digital_write/2 is undefined (module GPIO is not available or is yet to be defined)
+      lib/Blinky.ex:34
+
+    warning: GPIO.set_pin_mode/2 is undefined (module GPIO is not available or is yet to be defined)
+      lib/Blinky.ex:58
+
+    warning: GPIO.set_pin_mode/2 is undefined (module GPIO is not available or is yet to be defined)
+      lib/Blinky.ex:59
+    
+    warning: GPIO.set_pin_mode/2 is undefined (module GPIO is not available or is yet to be defined)
+      lib/Blinky.ex:65
+
+    warning: :atomvm.platform/0 is undefined (module :atomvm is not available or is yet to be defined)
+      lib/Blinky.ex:48
+
+    warning: :atomvm.platform/0 is undefined (module :atomvm is not available or is yet to be defined)
+      lib/Blinky.ex:57
+
+    st-flash 1.7.0
+    2023-10-31T10:47:20 INFO common.c: F42x/F43x: 256 KiB SRAM, 2048 KiB flash in at least 16 KiB pages.
+    file Blinky.avm md5 checksum: 3dca925a9616d4d65dc9d87fbf19af, stlink checksum: 0x00767ad5
+    2023-10-31T10:47:20 INFO common.c: Attempting to write 156172 (0x2620c) bytes to stm32 address: 134742016 (0x8080000)
+    EraseFlash - Sector:0x8 Size:0x20000 2023-10-31T10:47:22 INFO common.c: Flash page at addr: 0x08080000 erased
+    EraseFlash - Sector:0x9 Size:0x20000 2023-10-31T10:47:24 INFO common.c: Flash page at addr: 0x080a0000 erased
+    2023-10-31T10:47:24 INFO common.c: Finished erasing 2 pages of 131072 (0x20000) bytes
+    2023-10-31T10:47:24 INFO common.c: Starting Flash write for F2/F4/F7/L4
+    2023-10-31T10:47:24 INFO flash_loader.c: Successfully loaded flash loader in sram
+    2023-10-31T10:47:24 INFO flash_loader.c: Clear DFSR
+    2023-10-31T10:47:24 INFO common.c: enabling 32-bit flash writes
+    2023-10-31T10:47:26 INFO common.c: Starting verification of write complete
+    2023-10-31T10:47:27 INFO common.c: Flash written and verified! jolly good!

--- a/lib/mix/tasks/stm32_flash.ex
+++ b/lib/mix/tasks/stm32_flash.ex
@@ -1,0 +1,64 @@
+defmodule Mix.Tasks.Atomvm.Stm32.Flash do
+  use Mix.Task
+  alias Mix.Project
+  alias Mix.Tasks.Atomvm.Packbeam
+
+  def run(args) do
+    config = Project.config()
+
+    with {:atomvm, {:ok, avm_config}} <- {:atomvm, Keyword.fetch(config, :atomvm)},
+         {:args, {:ok, options}} <- {:args, parse_args(args)},
+         {:pack, {:ok, _}} <- {:pack, Packbeam.run(args)},
+         stflash_path <- System.get_env("ATOMVM_MIX_PLUGIN_STFLASH", <<"">>) do
+
+      flash_offset =
+        Map.get(options, :flash_offset, Keyword.get(avm_config, :flash_offset, 0x8080000))
+
+      flash(stflash_path, flash_offset)
+    else
+      {:atomvm, :error} ->
+        IO.puts("error: missing AtomVM project config.")
+        exit({:shutdown, 1})
+
+      {:args, :error} ->
+        IO.puts("Syntax: ")
+        exit({:shutdown, 1})
+
+      {:pack, _} ->
+        IO.puts("error: failed PackBEAM, target will not be flashed.")
+        exit({:shutdown, 1})
+    end
+  end
+
+  def flash(stflash_path, flash_offset) do
+    tool_args = [
+      "--reset",
+      "write",
+      "#{Project.config()[:app]}.avm",
+      "0x#{Integer.to_string(flash_offset, 16)}"
+    ]
+
+    tool_full_path = get_stflash_path(stflash_path)
+    System.cmd(tool_full_path, tool_args, stderr_to_stdout: true, into: IO.stream(:stdio, 1))
+  end
+
+  defp get_stflash_path(<<"">>) do
+    "st-flash"
+  end
+
+  defp parse_args(args) do
+    parse_args(args, %{})
+  end
+
+  defp parse_args([], accum) do
+    {:ok, accum}
+  end
+
+  defp parse_args([<<"--flash_offset">>, flash_offset | t], accum) do
+    parse_args(t, Map.put(accum, :flash_offset, flash_offset))
+  end
+
+  defp parse_args([_ | t], accum) do
+    parse_args(t, accum)
+  end
+end


### PR DESCRIPTION
Adds the `atomvm.stm32.flash` tast to the ExAtomVM mix plugin for flashing AtomVM mix projects to an STM32 device using the `st-flash` utility.