### PR TITLE
allow port "auto" config - that enables auto detect of port

### DIFF
--- a/lib/mix/tasks/esp32_flash.ex
+++ b/lib/mix/tasks/esp32_flash.ex
@@ -39,8 +39,6 @@ defmodule Mix.Tasks.Atomvm.Esp32.Flash do
     tool_args = [
       "--chip",
       chip,
-      "--port",
-      port,
       "--baud",
       baud,
       "--before",
@@ -58,6 +56,8 @@ defmodule Mix.Tasks.Atomvm.Esp32.Flash do
       "0x#{Integer.to_string(flash_offset, 16)}",
       "#{Project.config()[:app]}.avm"
     ]
+
+    tool_args = if port == "auto", do: tool_args, else: ["--port", port] ++ tool_args
 
     tool_full_path = get_esptool_path(idf_path)
     System.cmd(tool_full_path, tool_args, stderr_to_stdout: true, into: IO.stream(:stdio, 1))


### PR DESCRIPTION
Existing behaviour is kept - no defaults changed.

Esptool has auto-detect port features (when --port is left out), where it enumerates serial ports and finds the first port with esp32 connected.

Setting port to "auto" - (in combination with chip auto) - enables huge DX increase - where one can swap devices, and `mix atomvm.esp32.flash` - without having to figure out and configure the port.

Also avoids funny stuff like a macbook pro having different name for left/right side usb respectively.