### PR TITLE
Fix dropping list of runtime beams when performing a `packbeam` Mix task

### DIFF
--- a/lib/mix/tasks/packbeam.ex
+++ b/lib/mix/tasks/packbeam.ex
@@ -163,7 +163,7 @@ defmodule Mix.Tasks.Atomvm.Packbeam do
       if Keyword.get(dep.opts, :runtime, true) do
         ["#{dep.opts[:build]}/ebin" | runtime_deps(dep.deps) ++ acc]
       else
-        []
+        acc
       end
     end)
   end


### PR DESCRIPTION
I ran across a subtle bug with this function, basically if you ever included a single dependency in your `mix.exs` with `runtime: false` the code would drop the accumulation during the reduce.

This ensures we properly pack up runtime BEAMs, even if your project has some deps excluded.

🙂