### PR TITLE
Use bootloader settings for esp32

### DIFF
--- a/lib/mix/tasks/esp32_flash.ex
+++ b/lib/mix/tasks/esp32_flash.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Atomvm.Esp32.Flash do
          {:args, {:ok, options}} <- {:args, parse_args(args)},
          {:pack, {:ok, _}} <- {:pack, Packbeam.run(args)},
          idf_path <- System.get_env("IDF_PATH", <<"">>) do
-      chip = Map.get(options, :chip, Keyword.get(avm_config, :chip, "esp32"))
+      chip = Map.get(options, :chip, Keyword.get(avm_config, :chip, "auto"))
       port = Map.get(options, :port, Keyword.get(avm_config, :port, "/dev/ttyUSB0"))
       baud = Map.get(options, :baud, Keyword.get(avm_config, :baud, "115200"))
 
@@ -48,9 +48,9 @@ defmodule Mix.Tasks.Atomvm.Esp32.Flash do
       "write_flash",
       "-u",
       "--flash_mode",
-      "dio",
+      "keep",
       "--flash_freq",
-      "40m",
+      "keep",
       "--flash_size",
       "detect",
       "0x#{Integer.to_string(flash_offset, 16)}",


### PR DESCRIPTION
Changes harcoded settings to use defaults that can be set using `idf.py menuconfig` and read from the bootloader by `esptool` when flashing an esp32 device.

- Automatically detect chip by default.
- Add support for custom flash modes (`qio`, `qout`, etc...)
- Add support for custom flash speeds (`26m`, `80m`, etc...)