### PR TITLE
Add support for Raspberry Pi Pico devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,3 +413,31 @@ Example:
     2023-10-31T10:47:24 INFO common.c: enabling 32-bit flash writes
     2023-10-31T10:47:26 INFO common.c: Starting verification of write complete
     2023-10-31T10:47:27 INFO common.c: Flash written and verified! jolly good!
+
+### The `atomvm.pico.flash` task
+
+The `atomvm.pico.flash` task is used to flash your application to a micro-controller and executed by the AtomVM virtual machine.
+
+> Note.  Before running this task, you must flash the AtomVM virtual machine to the device.  See the [Getting Started](https://www.atomvm.net/doc/master/getting-started-guide.html) section if the [AtomVM documentation](https://www.atomvm.net/doc/master/) for information about how to flash the AtomVM image to a device.
+
+The `atomvm` properties list in the Mix project file (`mix.exs`) may contain the following entries related to this task:
+
+| Key | Type | Default | Value |
+|-----|------|----------|-------|
+| `pico_path` | string | "/run/media/${USER}/RPI-RP2" on linux; "/Volumes/RPI-RP2" on darwin (Mac) | The full path to the pico mount point |
+| `pico_reset` | string |"/dev/ttyACM*"  on linux; "/dev/cu.usbmodem14*" on darwin | The full path to the pico device to reset if required |
+| `picotool` | string | undefined | The full path to picotool executable (currently optional) |
+
+Properties in the `mix.exs` file may be over-ridden on the command line using long-style flags (prefixed by `--`) by the same name as the properties key.  For example, you can use the `--pico_path` option to specify or override the `pico_path` property in the above table.
+
+### The `atomvm.uf2create` task
+
+The `atomvm.uf2create` is use to create uf2 files appropriate for pico devices from a packed .avm application file, if the packed file does not exist the `atomvm.packbeam` task will be used to create the file (after compilation in necessary). Normally using this task manually is not required, it is called automatically by the `atomvm.pico.flash` if a uf2 file has not already been created.
+
+The `atomvm` properties list in the Mix project file (`mix.exs`) may contain the following entries related to this task:
+
+| Key | Type | Default | Value |
+|-----|------|----------|-------|
+| `app_start` | Address in hexademical format | 0x10180000 | The flash address to place the application |
+
+Properties in the `mix.exs` file may be over-ridden on the command line using long-style flags (prefixed by `--`) by the same name as the properties key.  For example, you can use the `--app_start` option to specify or override the `app_start` property in the above table.

--- a/lib/mix/tasks/pico_flash.ex
+++ b/lib/mix/tasks/pico_flash.ex
@@ -1,0 +1,189 @@
+defmodule Mix.Tasks.Atomvm.Pico.Flash do
+  use Mix.Task
+  alias Mix.Project
+  alias Mix.Tasks.Atomvm.Uf2create
+
+  def run(args) do
+    config = Project.config()
+
+    with {:atomvm, {:ok, avm_config}} <- {:atomvm, Keyword.fetch(config, :atomvm)},
+         {:args, {:ok, options}} <- {:args, parse_args(args)},
+         {:uf2, :ok} <- {:uf2, Uf2create.run(args)} do
+      pico_path = 
+        Map.get(options, :pico_path, Keyword.get(avm_config, :pico_path, System.get_env("ATOMVM_PICO_MOUNT_PATH", get_default_mount())))
+      pico_reset =
+        Map.get(options, :pico_reset, Keyword.get(avm_config, :pico_reset, System.get_env("ATOMVM_PICO_RESET_DEV", get_reset_base())))
+      picotool =
+        Map.get(options, :picotool, Keyword.get(avm_config, :picotool, System.get_env("ATOMVM_PICOTOOL_PATH", "#{:os.find_executable(~c"picotool")}")))
+
+      do_flash(pico_path, pico_reset, picotool)
+    else
+      {:atomvm, :error} ->
+        IO.puts("error: missing AtomVM project config.")
+        exit({:shutdown, 1})
+
+      {:args, :error} ->
+        IO.puts("Syntax: ")
+        exit({:shutdown, 1})
+
+      {:uf2, _} ->
+        IO.puts("error: failed to create uf2 file, target will not be flashed.")
+        exit({:shutdown, 1})
+    end
+  end
+
+  defp parse_args(args) do
+    parse_args(args, %{})
+  end
+
+  defp parse_args([], accum) do
+    {:ok, accum}
+  end
+
+  defp parse_args([<<"--pico_path">>, pico_path | t], accum) do
+    parse_args(t, Map.put(accum, :pico_path, pico_path))
+  end
+
+  defp parse_args([<<"--pico_reset">>, pico_reset | t], accum) do
+    parse_args(t, Map.put(accum, :pico_reset, pico_reset))
+  end
+
+  defp parse_args([<<"--picotool">>, picotool | t], accum) do
+    parse_args(t, Map.put(accum, :picotool, picotool))
+  end
+
+  defp parse_args([_ | t], accum) do
+    parse_args(t, accum)
+  end
+
+  defp get_default_mount() do
+    case :os.type() do
+      {_fam, :linux} -> "/run/media/#{:os.getenv(~c"USER")}/RPI-RP2"
+      {_fam, :darwin} -> "/Volumes/RPI-RP2"
+      _ -> ""
+    end
+  end
+
+  defp wait_for_mount(mount, count) when count < 30 do
+    case File.stat(mount) do
+      {:ok, filestat} ->
+        case Map.get(filestat, :type) do
+          :directory ->
+            :ok
+          _ ->
+            IO.puts("Object found at #{mount} is not a directory")
+            exit({:shutdown, 1})
+        end
+      {:error, :enoent} ->
+        Process.sleep(1000)
+        wait_for_mount(mount, count + 1)
+      error ->
+        IO.puts("unexpected error: #{error} while checking pico mount path.")
+        exit({:shutdown, 1})
+    end
+  end
+
+  defp wait_for_mount(_, 30) do
+    IO.puts("error: Pico not mounted after 30 seconds. giving up...")
+    exit({:shutdown, 1})
+  end
+
+  defp check_pico_mount(mount) do
+    case File.stat(<<"#{mount}">>) do
+      {:ok, info} ->
+        case Map.get(info, :type) do
+          :directory ->
+            :ok
+          _ ->
+            IO.puts("error: object at pico mount path not a directory. Abort!")
+            exit({:shutdown, 1})
+        end
+      _ ->
+        IO.puts("error: Pico not mounted. Abort!")
+        exit({:shutdown, 1})
+    end
+  end
+
+  defp get_stty_file_flag() do
+    case :os.type() do
+      {_fam, :linux} -> "-F"
+      _ -> "-f"
+    end
+  end
+
+  defp get_reset_base() do
+    case :os.type() do
+      {_fam, :linux} -> "/dev/ttyACM*"
+      {_fam, :darwin} -> "/dev/cu.usbmodem14*"
+      _ -> ""
+    end
+  end
+
+  defp needs_reset(resetdev) do
+    case Path.wildcard(resetdev) do
+      [] ->
+        false
+      [device | _t] ->
+        case File.stat(device) do
+          {:ok, info} ->
+            case Map.get(info, :type) do
+              :device -> {true, device}
+              _ -> false
+            end
+          _ ->
+            false
+        end
+      _ ->
+        false
+    end
+  end
+
+  defp do_reset(resetdev, picotool) do
+    flag = get_stty_file_flag()
+    cmd_args = ["#{flag}", "#{resetdev}", "1200"]
+
+    case System.cmd("stty", cmd_args) do
+      {"", 0} ->
+        # Pause to let the device settle
+        Process.sleep(200)
+      error ->
+        case picotool do
+          false ->
+            IO.puts("Error: #{error}\nUnable to locate 'picotool', close the serial monitor before flashing, or install picotool for automatic disconnect and BOOTSEL mode.")
+            exit({:shutdown, 1})
+          _ ->
+            IO.puts("Warning: #{error}\nFor faster flashing remember to disconnect serial monitor first.")
+            reset_args = ["reboot", "-f", "-u"]
+            IO.puts("Disconnecting serial monitor with `picotool #{:lists.join(" ", reset_args)}` in 5 seconds...")
+            Process.sleep(5000)
+            case :string.trim(System.cmd(picotool, reset_args)) do
+              {status, 0} ->
+                case status do
+                  "The device was asked to reboot into BOOTSEL mode." ->
+                    :ok
+                  pt_error ->
+                    IO.puts("Failed to prepare pico for flashing: #{pt_error}")
+                    exit({:shutdown, 1})
+                end
+              _ ->
+                IO.puts("Failed to prepare pico for flashing: #{error}")
+            end
+        end
+    end
+  end
+
+  defp do_flash(pico_path, pico_reset, picotool) do
+    case needs_reset(pico_reset) do
+      false ->
+        :ok
+      {true, reset_port} ->
+        do_reset(reset_port, picotool)
+        IO.puts("Waiting for the device at path #{pico_path} to settle and mount...")
+        wait_for_mount(pico_path, 0)
+    end
+
+    check_pico_mount(pico_path)
+    _bytes = File.copy!("#{Project.config()[:app]}.uf2", "#{pico_path}/#{Project.config()[:app]}.uf2", :infinity)
+    IO.puts("Successfully loaded #{Project.config()[:app]} to the pico device at #{pico_path}.")
+  end
+end

--- a/lib/mix/tasks/uf2create.ex
+++ b/lib/mix/tasks/uf2create.ex
@@ -1,0 +1,89 @@
+defmodule Mix.Tasks.Atomvm.Uf2create do
+  use Mix.Task
+  alias Mix.Project
+  alias Mix.Tasks.Atomvm.Packbeam
+  # require :uf2tool
+
+  def run(args) do
+    config = Project.config()
+
+    with {:atomvm, {:ok, avm_config}} <- {:atomvm, Keyword.fetch(config, :atomvm)},
+         {:args, {:ok, options}} <- {:args, parse_args(args)},
+         {:pack, {:ok, _}} <- {:pack, Packbeam.run(args)} do
+      app_start =
+        parse_addr(Keyword.get(avm_config, :app_start, Map.get(options, :app_start, System.get_env("ATOMVM_PICO_APP_START", "0x10180000"))))
+      family_id =
+        validate_fam(Keyword.get(avm_config, :family_id, Map.get(options, :family_id, System.get_env("ATOMVM_PICO_UF2_FAMILY", "rp2040"))))
+
+      :ok = :uf2tool.uf2create("#{config[:app]}.uf2", family_id, app_start, "#{config[:app]}.avm")
+      IO.puts("Created #{config[:app]}.uf2")
+    else
+      {:atomvm, :error} ->
+        IO.puts("error: missing AtomVM project config.")
+        exit({:shutdown, 1})
+
+      {:args, :error} ->
+        IO.puts("Syntax: ")
+        exit({:shutdown, 1})
+
+      {:pack, _} ->
+        IO.puts("error: failed PackBEAM, uf2 file will not be created.")
+        exit({:shutdown, 1})
+    end
+  end
+
+  defp parse_args(args) do
+    parse_args(args, %{})
+  end
+
+  defp parse_args([], accum) do
+    {:ok, accum}
+  end
+
+  defp parse_args([<<"--app_start">>, app_start | t], accum) do
+    parse_args(t, Map.put(accum, :app_start, app_start))
+  end
+
+  defp parse_args([<<"--family_id">>, family_id | t], accum) do
+    parse_args(t, Map.put(accum, :family_id, family_id))
+  end
+
+  defp parse_args([_ | t], accum) do
+    parse_args(t, accum)
+  end
+
+  defp parse_addr("0x" <> addrhex) do
+    {address, ""} = Integer.parse(addrhex, 16)
+    address
+  end
+
+  defp parse_addr("16#" <> addrhex) do
+    {address, ""} = Integer.parse(addrhex, 16)
+    address
+  end
+
+  defp parse_addr(addrdec) do
+    {address, ""} = Integer.parse(addrdec)
+    address
+  end
+
+  defp validate_fam(family) do
+    case family do
+      "rp2040" -> :rp2040
+      ":rp2040" -> :rp2040
+      :rp2040 -> :rp2040
+      "rp2035" -> :data
+      ":rp2035" -> :data
+      :rp2035 -> :data
+      "data" -> :data
+      ":data" -> :data
+      :data -> :data
+      "universal" -> :universal
+      ":universal" -> :universal
+      :universal -> :universal
+      unsupported ->
+        IO.puts("Unsupported 'family_id' #{unsupported}")
+        exit({:shutdown, 1})
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule ExAtomVM.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:uf2tool,  "1.1.0"}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]


### PR DESCRIPTION
Adds atomvm.uf2create and atomvm.pico.flash tasks. The flash task depends on the atomvm.uf2create task which in turn depends on the atomvm.packbeam task, so `mix atomvm.pico.flash` may be used directly without running the lower lever uf2create task (or packbeam) first.