### PR TITLE
Allow erlang:raise/2 (needed for try/catch) (OTP >= 26)

### DIFF
--- a/priv/funcs.txt
+++ b/priv/funcs.txt
@@ -346,6 +346,7 @@ erlang:process_flag/2
 erlang:process_flag/3
 erlang:process_info/2
 erlang:put/2
+erlang:raise/2
 erlang:raise/3
 erlang:ref_to_list/1
 erlang:register/2


### PR DESCRIPTION
seems to be OTP >= 26
doing any try/catch, say:

    rtc_data =
      try do
        :esp.rtc_slow_get_binary()
      catch
        error ->
          IO.inspect("Error retrieving binary data: #{error}")
          nil
      end

yields:

```
error: following modules or functions are not available on AtomVM:
* erlang:raise/2
```

Tested PR both paths on device, so assume it's supported.