### PR TITLE
Allow erlang: fadd/2 fdiv/2 fmul/2 fnegate/1 fsub/2

### DIFF
--- a/priv/funcs.txt
+++ b/priv/funcs.txt
@@ -276,11 +276,16 @@ erlang:error/2
 erlang:error/3
 erlang:exit/1
 erlang:exit/2
+erlang:fadd/2
+erlang:fdiv/2
 erlang:float_to_binary/1
 erlang:float_to_binary/2
 erlang:float_to_list/1
 erlang:float_to_list/2
 erlang:floor/1
+erlang:fmul/2
+erlang:fnegate/1
+erlang:fsub/2
 erlang:function_exported/3
 erlang:fun_to_list/1
 erlang:garbage_collect/0


### PR DESCRIPTION
Needed/generated when a float, isn't known at compilation time and comes from a measurement or function. Experienced in real world when doing voltage calculations on ADC measurements.

replicate issue:

```
    test_binary = :binary.part("5545.48587", 2, byte_size("5545.48587") - 2)

    # NB test_binary has to be somewhat "functional"/chained in origin eg. using below fixed binary doesn't call fadd/2 etc.
    # test_binary = <<"45.48587">>

    test_float = :erlang.binary_to_float(test_binary)

    fadd2 = test_float + 10.0
    fsub2 = test_float - 10.0
    fdiv2 = test_float / 10.0
    fmul2 = test_float * 10.0
```


not able to exercise and test fnegate/1 - suggestions?
`fnegate1 = -test_float`

See https://github.com/erlang/otp/blob/c24e439f7113fd702b918ca7f38b189264e9c9b3/lib/compiler/src/beam_asm.erl#L384
