### PR TITLE
Update uf2create task Raspberry Pi Pico 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,5 +439,6 @@ The `atomvm` properties list in the Mix project file (`mix.exs`) may contain the
 | Key | Type | Default | Value |
 |-----|------|----------|-------|
 | `app_start` | Address in hexademical format | 0x10180000 | The flash address to place the application |
+| `family_id` | atom or string | `universal` | The flavor of uf2 to create; `rp2040`, `rp2350_riscv`, `rp2350_arm_s`, `rp2350_arm_ns`, `data`, `absolute`, or `universal` |
 
 Properties in the `mix.exs` file may be over-ridden on the command line using long-style flags (prefixed by `--`) by the same name as the properties key.  For example, you can use the `--app_start` option to specify or override the `app_start` property in the above table.

--- a/lib/mix/tasks/uf2create.ex
+++ b/lib/mix/tasks/uf2create.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Atomvm.Uf2create do
       app_start =
         parse_addr(Keyword.get(avm_config, :app_start, Map.get(options, :app_start, System.get_env("ATOMVM_PICO_APP_START", "0x10180000"))))
       family_id =
-        validate_fam(Keyword.get(avm_config, :family_id, Map.get(options, :family_id, System.get_env("ATOMVM_PICO_UF2_FAMILY", "rp2040"))))
+        validate_fam(Keyword.get(avm_config, :family_id, Map.get(options, :family_id, System.get_env("ATOMVM_PICO_UF2_FAMILY", :universal))))
 
       :ok = :uf2tool.uf2create("#{config[:app]}.uf2", family_id, app_start, "#{config[:app]}.avm")
       IO.puts("Created #{config[:app]}.uf2")
@@ -72,9 +72,18 @@ defmodule Mix.Tasks.Atomvm.Uf2create do
       "rp2040" -> :rp2040
       ":rp2040" -> :rp2040
       :rp2040 -> :rp2040
-      "rp2035" -> :data
-      ":rp2035" -> :data
-      :rp2035 -> :data
+      "rp2035_riscv" -> :rp2035_riscv
+      ":rp2035_riscv" -> :rp2035_riscv
+      :rp2035_riscv -> :rp2035_riscv
+      "rp2035_arm_s" -> :rp2035_arm_s
+      ":rp2035_arm_s" -> :rp2035_arm_s
+      :rp2035_arm_s -> :rp2035_arm_s
+      "rp2035_arm_ns" -> :rp2035_arm_ns
+      ":rp2035_arm_ns" -> :rp2035_arm_ns
+      :rp2035_arm_ns -> :rp2035_arm_ns
+      "absolute" -> :absolute
+      ":absolute" -> :absolute
+      :universal -> :absolute
       "data" -> :data
       ":data" -> :data
       :data -> :data


### PR DESCRIPTION
Updates binary formats to updated uf2tool formats, changes the default format to univeral, which is compatible with all Pico SOCs.