### PR TITLE
Elixir >= 1.17, handle simplest map dot field notation

### DIFF
--- a/lib/mix/tasks/check.ex
+++ b/lib/mix/tasks/check.ex
@@ -193,6 +193,14 @@ defmodule Mix.Tasks.Atomvm.Check do
     missing_instructions = MapSet.difference(instructions_set, avail_instructions)
 
     if MapSet.size(missing_instructions) != 0 do
+      if MapSet.member?(missing, "elixir_erl_pass:parens_map_field/2") do
+        IO.puts("""
+        Error:
+          using module.function() notation (with parentheses) to fetch
+          map.field() is deprecated,
+          you must remove the parentheses: map.field
+        """)
+      end
       IO.puts("error: following missing instructions are used:")
       print_list(missing_instructions)
       IO.puts("")

--- a/priv/funcs.txt
+++ b/priv/funcs.txt
@@ -1646,3 +1646,4 @@ Elixir.WithClauseError:module_info/1
 Elixir.WithClauseError:__struct__/0
 Elixir.WithClauseError:__struct__/1
 elixir_env:to_caller/1
+elixir_erl_pass:no_parens_remote/2


### PR DESCRIPTION
Simplest map dot field access on Elixir >= 1.17 requires the 'elixir_erl_pass:no_parens_remote/2' function. Due to runtime deprecations checks https://github.com/elixir-lang/elixir/blob/main/lib/elixir/src/elixir_erl_pass.erl

Eg:

```elixir
    test = %{a: 1, b: fn -> 42 end}

    IO.inspect("works if elixir_erl_pass:no_parens_remote/2 allowed: #{test.a}")
    IO.inspect("works if elixir_erl_pass:no_parens_remote/2 allowed: #{test.b.()}")
```

Additionally using deprecated syntax eg. `test.a()` will run into requiring elixir_erl_pass:parens_map_field/2 - allowing that will cause runtime crashes if test.a() is used in code, and thus the check is kept and special error message is logged.

This is a short term solution, long term we should stub out elixir_erl_pass in atomvm itself.