### PR TITLE
Use the Config module instead of Mix.Config is deprecated

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
@@ -27,4 +27,4 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env()}.exs"
+#     import_config "#{config_env()}.exs"

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExAtomVM.MixProject do
     [
       app: :exatomvm,
       version: "0.1.0",
-      elixir: "~> 1.8",
+      elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
@@ -21,7 +21,7 @@ defmodule ExAtomVM.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:uf2tool,  "1.1.0"}
+      {:uf2tool, "1.1.0"}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,3 @@
+%{
+  "uf2tool": {:hex, :uf2tool, "1.1.0", "7091931234ca5a256b66ea691983867d51229798622d083f85c1ad779798a734", [:rebar3], [], "hexpm", "1a7e5ca7ef3d19c7a0b0acf3db804b3188e0980884acffa13fd57d733507b73d"},
+}


### PR DESCRIPTION
Gets rid of:
warning: use Mix.Config is deprecated. Use the Config module instead
  config/config.exs:3