### PR TITLE
Fix pythonx: esptool to 5.0.2 release

### DIFF
--- a/lib/esptool_helper.ex
+++ b/lib/esptool_helper.ex
@@ -19,7 +19,7 @@ defmodule ExAtomVM.EsptoolHelper do
         version = "0.0.0"
         requires-python = "==3.13.*"
         dependencies = [
-          "esptool @ git+https://github.com/espressif/esptool.git@6f0d779"
+          "esptool==5.0.2"
         ]
         """)
 

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule ExAtomVM.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:uf2tool, "1.1.0"},
+      {:uf2tool, "1.1.0", runtime: false},
       {:ex_doc, "~> 0.20", only: :dev, runtime: false},
       {:pythonx, "~> 0.4.0", runtime: false, optional: true},
       {:req, "~> 0.5.0", runtime: false, optional: true}


### PR DESCRIPTION
Script was causing errors due esptool python incompatibilities ("Click" dependency apparently). Sin comentario, but we were using a dev commit before.. so let's see.

Also mark uf2tool as runtime false.