### PR TITLE
ESP32: Check for AtomVM on pythonx flash

### DIFF
--- a/lib/esptool_helper.ex
+++ b/lib/esptool_helper.ex
@@ -36,6 +36,21 @@ defmodule ExAtomVM.EsptoolHelper do
       if not Enum.member?(tool_args, "--port") do
         selected_device = select_device()
 
+        if not Map.get(selected_device, "atomvm_installed", false) do
+          IO.puts("""
+
+            AtomVM doesn't seem to be installed on #{selected_device["chip_family_name"]}!
+
+            Install using 'mix atomvm.esp32.install' or
+
+            https://doc.atomvm.org/main/getting-started-guide.html#flashing-a-binary-image-to-esp32
+
+            (override check using 'mix atomvm.esp32.flash --port #{selected_device["port"]}')
+          """)
+
+          exit({:shutdown, 1})
+        end
+
         ["--port", selected_device["port"]] ++ tool_args
       else
         tool_args
@@ -217,7 +232,7 @@ defmodule ExAtomVM.EsptoolHelper do
           |> Enum.with_index(1)
           |> Enum.each(fn {device, index} ->
             IO.puts(
-              "#{index}. #{device["chip_family_name"]} - Port: #{device["port"]} MAC: #{device["mac_address"]}"
+              "#{index}. #{String.pad_trailing(device["chip_family_name"], 8, " ")} MAC: #{device["mac_address"]} AtomVM installed: #{format_atomvm_status(device["atomvm_installed"])} - Port: #{device["port"]}"
             )
           end)
 
@@ -238,4 +253,7 @@ defmodule ExAtomVM.EsptoolHelper do
 
     selected_device
   end
+
+  def format_atomvm_status(true), do: "✅"
+  def format_atomvm_status(_), do: "❌"
 end

--- a/lib/mix/tasks/esp32.info.ex
+++ b/lib/mix/tasks/esp32.info.ex
@@ -3,13 +3,14 @@ defmodule Mix.Tasks.Atomvm.Esp32.Info do
   Mix task to get information about connected ESP32 devices.
   """
   use Mix.Task
+  alias ExAtomVM.EsptoolHelper
 
   @shortdoc "Get information about connected ESP32 devices"
 
   @impl Mix.Task
   def run(_args) do
-    with :ok <- ExAtomVM.EsptoolHelper.setup(),
-         devices <- ExAtomVM.EsptoolHelper.connected_devices() do
+    with :ok <- EsptoolHelper.setup(),
+         devices <- EsptoolHelper.connected_devices() do
       case length(devices) do
         0 ->
           IO.puts(
@@ -23,7 +24,7 @@ defmodule Mix.Tasks.Atomvm.Esp32.Info do
       if length(devices) > 1 do
         Enum.each(devices, fn device ->
           IO.puts(
-            "#{format_atomvm_status(device["atomvm_installed"])}#{device["chip_family_name"]} - Port: #{device["port"]}"
+            "#{EsptoolHelper.format_atomvm_status(device["atomvm_installed"])}#{String.pad_trailing(device["chip_family_name"], 8, " ")} - Port: #{device["port"]}"
           )
         end)
       end
@@ -32,7 +33,7 @@ defmodule Mix.Tasks.Atomvm.Esp32.Info do
         IO.puts("\n━━━━━━━━━━━━━━━━━━━━━━")
 
         IO.puts(
-          "#{format_atomvm_status(device["atomvm_installed"])}#{device["chip_family_name"]} - Port: #{device["port"]}"
+          "#{EsptoolHelper.format_atomvm_status(device["atomvm_installed"])}#{device["chip_family_name"]} - Port: #{device["port"]}"
         )
 
         IO.puts("USB_MODE: #{device["usb_mode"]}")
@@ -100,7 +101,4 @@ defmodule Mix.Tasks.Atomvm.Esp32.Info do
   end
 
   defp sanitize_string(_), do: "<invalid>"
-
-  defp format_atomvm_status(true), do: "✅"
-  defp format_atomvm_status(_), do: "❌"
 end

--- a/lib/mix/tasks/esp32_flash.ex
+++ b/lib/mix/tasks/esp32_flash.ex
@@ -118,7 +118,7 @@ defmodule Mix.Tasks.Atomvm.Esp32.Flash do
 
     case Code.ensure_loaded(Pythonx) do
       {:module, Pythonx} ->
-        IO.inspect("Flashing using Pythonx installed esptool..")
+        IO.puts("Flashing using Pythonx installed esptool..")
         ExAtomVM.EsptoolHelper.setup()
 
         case ExAtomVM.EsptoolHelper.flash_pythonx(tool_args) do
@@ -127,7 +127,7 @@ defmodule Mix.Tasks.Atomvm.Esp32.Flash do
         end
 
       _ ->
-        IO.inspect("Flashing using esptool..")
+        IO.puts("Flashing using esptool..")
         tool_full_path = get_esptool_path(idf_path)
         System.cmd(tool_full_path, tool_args, stderr_to_stdout: true, into: IO.stream(:stdio, 1))
     end


### PR DESCRIPTION
For maximum handholding and success rate, we add a check for AtomVM being installed on device when flashing a project.
(as it's trivial and data is already there)

This adds a device check for AtomVM being installed on device, including override instructions.

We also show if AtomVM is installed in the multi device selector.

Also some very minor refactors..

eg:

```
Multiple ESP32 devices found:
1. ESP32    MAC: XX:XX:FA:66:XX:XX AtomVM installed: ❌ - Port: /dev/cu.usbserial-01ED9ZZZ
2. ESP32-S3 MAC: XX:XX:AB:F8:XX:XX AtomVM installed: ✅ - Port: /dev/cu.usbmodem1101

Select device (1-2): 1

  AtomVM doesn't seem to be installed on ESP32!

  Install using 'mix atomvm.esp32.install' or

  https://doc.atomvm.org/main/getting-started-guide.html#flashing-a-binary-image-to-esp32

  (override check using 'mix atomvm.esp32.flash --port /dev/cu.usbserial-01ED9ZZZ')
```

(added padding and moved port to end so it aligns)