### PR TITLE
Remove missing avm_deps directory warning

### DIFF
--- a/lib/mix/tasks/packbeam.ex
+++ b/lib/mix/tasks/packbeam.ex
@@ -180,12 +180,6 @@ defmodule Mix.Tasks.Atomvm.Packbeam do
           {:ok, Path.join(prefix, "lib/AtomVM/ebin/")}
         else
           _ ->
-            IO.puts("No avm_deps directory found.")
-
-            IO.puts(
-              "This message can be safely ignored when standard libraries are already flashed to lib partition."
-            )
-
             {:error, :no_avm_deps_path}
         end
     end


### PR DESCRIPTION
Confusing DX for beginners, and I honestly don't know/understand what it's for.

So let's just remove the warning.