### PR TITLE
Fix: Avoid deprecation warnings esptool/pythonx

### DIFF
--- a/lib/mix/tasks/esp32_flash.ex
+++ b/lib/mix/tasks/esp32_flash.ex
@@ -121,6 +121,18 @@ defmodule Mix.Tasks.Atomvm.Esp32.Flash do
         IO.puts("Flashing using Pythonx installed esptool..")
         ExAtomVM.EsptoolHelper.setup()
 
+        # avoid deprecation warnings, as we know we are esptool version 5+, when using Pythonx.
+        tool_args =
+          Enum.map(tool_args, fn
+            "--flash_mode" -> "--flash-mode"
+            "--flash_freq" -> "--flash-freq"
+            "--flash_size" -> "--flash-size"
+            "default_reset" -> "default-reset"
+            "hard_reset" -> "hard-reset"
+            "write_flash" -> "write-flash"
+            arg -> arg
+          end)
+
         case ExAtomVM.EsptoolHelper.flash_pythonx(tool_args) do
           true -> exit({:shutdown, 0})
           false -> exit({:shutdown, 1})


### PR DESCRIPTION
Since pythonx/esptool is version locked 5.0.2 we are certain we are version 5+, and can use the renamed options(sic!)

Avoids confusing warnings:
```
Flashing using Pythonx installed esptool..
Warning: Deprecated: Option '--flash_mode' is deprecated. Use '--flash-mode' instead.
Warning: Deprecated: Option '--flash_freq' is deprecated. Use '--flash-freq' instead.
Warning: Deprecated: Option '--flash_size' is deprecated. Use '--flash-size' instead.
Warning: Deprecated: Choice 'default_reset' for option '--before' is deprecated. Use 'default-reset' inste
ad.
Warning: Deprecated: Choice 'hard_reset' for option '--after' is deprecated. Use 'hard-reset' instead.
Warning: Deprecated: Command 'write_flash' is deprecated. Use 'write-flash' instead.
esptool v5.0.2
Connected to ESP32-S2 on /dev/ttyACM0:
Chip type: ESP32-S2FNR2 (revision v1.0)
...
```