### PR TITLE
Fix 2 typing violations

### DIFF
--- a/lib/mix/tasks/pico_flash.ex
+++ b/lib/mix/tasks/pico_flash.ex
@@ -233,14 +233,14 @@ defmodule Mix.Tasks.Atomvm.Pico.Flash do
         case picotool do
           false ->
             IO.puts(
-              "Error: #{error}\nUnable to locate 'picotool', close the serial monitor before flashing, or install picotool for automatic disconnect and BOOTSEL mode."
+              "Error: #{inspect(error)}\nUnable to locate 'picotool', close the serial monitor before flashing, or install picotool for automatic disconnect and BOOTSEL mode."
             )
 
             exit({:shutdown, 1})
 
           _ ->
             IO.puts(
-              "Warning: #{error}\nFor faster flashing remember to disconnect serial monitor first."
+              "Warning: #{inspect(error)}\nFor faster flashing remember to disconnect serial monitor first."
             )
 
             reset_args = ["reboot", "-f", "-u"]


### PR DESCRIPTION
Elixir 1.19:

```
Compiling 2 files (.ex)
     warning: incompatible value given to string interpolation:

         error

     it has type:

         -dynamic({term(), term()})-

     but expected a type that implements the String.Chars protocol.
     You either passed the wrong value or you must:

     1. convert the given value to a string explicitly
        (use inspect/1 if you want to convert any data structure to a string)
     2. implement the String.Chars protocol

     where "error" was given the type:

         # type: dynamic({term(), term()})
         # from: lib/mix/tasks/pico_flash.ex:232:7
         error

     hint: the String.Chars protocol is implemented for the following types:

         dynamic(
           %Date{} or %DateTime{} or %NaiveDateTime{} or %Time{} or %URI{} or %Version{} or
             %Version.Requirement{}
         ) or atom() or binary() or empty_list() or float() or integer() or non_empty_list(term(), term())

     typing violation found at:
     │
 236 │               "Error: #{error}\nUnable to locate 'picotool', close the serial monitor before flashing, or install picotool for automatic disconnect and BOOTSEL mode."
     │               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     │
     └─ lib/mix/tasks/pico_flash.ex:236: Mix.Tasks.Atomvm.Pico.Flash.do_reset/2

     warning: incompatible value given to string interpolation:

         error

     it has type:

         -dynamic({term(), term()})-

     but expected a type that implements the String.Chars protocol.
     You either passed the wrong value or you must:

     1. convert the given value to a string explicitly
        (use inspect/1 if you want to convert any data structure to a string)
     2. implement the String.Chars protocol

     where "error" was given the type:

         # type: dynamic({term(), term()})
         # from: lib/mix/tasks/pico_flash.ex:232:7
         error

     hint: the String.Chars protocol is implemented for the following types:

         dynamic(
           %Date{} or %DateTime{} or %NaiveDateTime{} or %Time{} or %URI{} or %Version{} or
             %Version.Requirement{}
         ) or atom() or binary() or empty_list() or float() or integer() or non_empty_list(term(), term())

     typing violation found at:
     │
 243 │               "Warning: #{error}\nFor faster flashing remember to disconnect serial monitor first."
     │               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     │
     └─ lib/mix/tasks/pico_flash.ex:243: Mix.Tasks.Atomvm.Pico.Flash.do_reset/2
```